### PR TITLE
DPR2-2684: Strip commas for numeric columns.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/landingzoneprocessing/conversion/CsvRowToAvroRecordConverter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/landingzoneprocessing/conversion/CsvRowToAvroRecordConverter.kt
@@ -104,10 +104,10 @@ class CsvRowToAvroRecordConverter(
                 try {
                     when (actualType) {
                         Schema.Type.STRING -> resultRecord.put(columnName, stringVal)
-                        Schema.Type.INT -> resultRecord.put(columnName, stringVal.toInt())
-                        Schema.Type.LONG -> resultRecord.put(columnName, stringVal.toLong())
-                        Schema.Type.FLOAT -> resultRecord.put(columnName, stringVal.toFloat())
-                        Schema.Type.DOUBLE -> resultRecord.put(columnName, stringVal.toDouble())
+                        Schema.Type.INT -> resultRecord.put(columnName, stripCommas(stringVal).toInt())
+                        Schema.Type.LONG -> resultRecord.put(columnName, stripCommas(stringVal).toLong())
+                        Schema.Type.FLOAT -> resultRecord.put(columnName, stripCommas(stringVal).toFloat())
+                        Schema.Type.DOUBLE -> resultRecord.put(columnName, stripCommas(stringVal).toDouble())
                         Schema.Type.BOOLEAN -> resultRecord.put(columnName, stringVal.toBooleanStrict())
                         else -> {
                             val msg = "We do not support type $type for field $columnName"
@@ -126,6 +126,11 @@ class CsvRowToAvroRecordConverter(
             }
         }
         return SuccessfulConversion(resultRecord)
+    }
+
+    // Useful for handling CSV files that format numeric fields with commas
+    private fun stripCommas(value: String): String {
+        return value.replace(",", "")
     }
 
     private fun addDmsColumnsToRow(row: List<String>): List<String> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/landingzoneprocessing/conversion/CsvRowToAvroRecordConverterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/landingzoneprocessing/conversion/CsvRowToAvroRecordConverterTest.kt
@@ -2,12 +2,14 @@ package uk.gov.justice.digital.hmpps.landingzoneprocessing.conversion
 
 import com.amazonaws.services.lambda.runtime.LambdaLogger
 import com.amazonaws.services.lambda.runtime.logging.LogLevel
+import com.github.doyaaaaaken.kotlincsv.dsl.csvReader
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.landingzoneprocessing.conversion.CsvRowToAvroRecordConverter.CsvRowToAvroConversionResult.*
 import uk.gov.justice.digital.hmpps.landingzoneprocessing.testhelpers.TestHelpers.avroSchemaFromResources
+import java.io.File
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
@@ -182,6 +184,32 @@ class CsvRowToAvroRecordConverterTest {
             assertEquals(6.0f, actual.get("a_float_column2") as Float)
             assertEquals(7.0, actual.get("a_double_column") as Double)
             assertEquals(8.0, actual.get("a_double_column2") as Double)
+            assertEquals(true, actual.get("a_boolean_column") as Boolean)
+            assertEquals(false, actual.get("a_boolean_column2") as Boolean)
+        }
+    }
+
+    @Test
+    fun `should convert int, long, float and double formatted with commas`() {
+        val row = listOf(
+            "str", "str2", "1,000", "2,000", "3,000", "4,000", "5,000.00", "6,000", "7,000.03", "8,000", "true", "false"
+        )
+
+        val result = underTest.toAvro(schema, row)
+
+        assertTrue(result is SuccessfulConversion)
+        if (result is SuccessfulConversion) {
+            val actual = result.avro
+            assertEquals("str", actual.get("a_string_column") as String)
+            assertEquals("str2", actual.get("a_string_column2") as String)
+            assertEquals(1000, actual.get("an_int_column") as Int)
+            assertEquals(2000, actual.get("an_int_column2") as Int)
+            assertEquals(3000L, actual.get("a_long_column") as Long)
+            assertEquals(4000L, actual.get("a_long_column2") as Long)
+            assertEquals(5000.0f, actual.get("a_float_column") as Float)
+            assertEquals(6000.0f, actual.get("a_float_column2") as Float)
+            assertEquals(7000.03, actual.get("a_double_column") as Double)
+            assertEquals(8000.0, actual.get("a_double_column2") as Double)
             assertEquals(true, actual.get("a_boolean_column") as Boolean)
             assertEquals(false, actual.get("a_boolean_column2") as Boolean)
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/landingzoneprocessing/conversion/CsvRowToAvroRecordConverterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/landingzoneprocessing/conversion/CsvRowToAvroRecordConverterTest.kt
@@ -2,14 +2,12 @@ package uk.gov.justice.digital.hmpps.landingzoneprocessing.conversion
 
 import com.amazonaws.services.lambda.runtime.LambdaLogger
 import com.amazonaws.services.lambda.runtime.logging.LogLevel
-import com.github.doyaaaaaken.kotlincsv.dsl.csvReader
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.landingzoneprocessing.conversion.CsvRowToAvroRecordConverter.CsvRowToAvroConversionResult.*
 import uk.gov.justice.digital.hmpps.landingzoneprocessing.testhelpers.TestHelpers.avroSchemaFromResources
-import java.io.File
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
@@ -200,8 +198,6 @@ class CsvRowToAvroRecordConverterTest {
         assertTrue(result is SuccessfulConversion)
         if (result is SuccessfulConversion) {
             val actual = result.avro
-            assertEquals("str", actual.get("a_string_column") as String)
-            assertEquals("str2", actual.get("a_string_column2") as String)
             assertEquals(1000, actual.get("an_int_column") as Int)
             assertEquals(2000, actual.get("an_int_column2") as Int)
             assertEquals(3000L, actual.get("a_long_column") as Long)
@@ -210,8 +206,6 @@ class CsvRowToAvroRecordConverterTest {
             assertEquals(6000.0f, actual.get("a_float_column2") as Float)
             assertEquals(7000.03, actual.get("a_double_column") as Double)
             assertEquals(8000.0, actual.get("a_double_column2") as Double)
-            assertEquals(true, actual.get("a_boolean_column") as Boolean)
-            assertEquals(false, actual.get("a_boolean_column2") as Boolean)
         }
     }
 


### PR DESCRIPTION
The lambda will now strip out comma characters from numeric fields before converting them to the appropriate numeric type.

E.g. 1,200 will become 1200 before conversion to an int.